### PR TITLE
Implemented builder approach in configuration and added _blank option

### DIFF
--- a/config/nova-links.php
+++ b/config/nova-links.php
@@ -4,5 +4,4 @@ return [
     'links' => [
         'Nova Docs' => 'http://nova.laravel.com/docs'
     ],
-    'open_in_new_tab' => false,
 ];

--- a/config/nova-links.php
+++ b/config/nova-links.php
@@ -3,5 +3,6 @@
 return [
     'links' => [
         'Nova Docs' => 'http://nova.laravel.com/docs'
-    ]
+    ],
+    'open_in_new_tab' => false,
 ];

--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -7,7 +7,8 @@
 <ul class="list-reset mb-8">
     @foreach (config('nova-links.links') as $name => $link)
         <li class="leading-wide mb-4 text-sm">
-            <a href="{{$link}}" class="text-white ml-8 no-underline dim">
+            <a href="{{$link}}" class="text-white ml-8 no-underline dim"
+                    {{ config('nova-links.open_in_new_tab') ? 'target="_blank"' : '' }}>
                 {{ $name }}
             </a>
         </li>

--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -5,11 +5,11 @@
     <span class="sidebar-label">{{ __('Links') }}</span>
 </h3>
 <ul class="list-reset mb-8">
-    @foreach (config('nova-links.links') as $name => $link)
+    @foreach ($links as $link)
         <li class="leading-wide mb-4 text-sm">
-            <a href="{{$link}}" class="text-white ml-8 no-underline dim"
-                    {{ config('nova-links.open_in_new_tab') ? 'target="_blank"' : '' }}>
-                {{ $name }}
+            <a href="{{ $link['href'] }}" class="text-white ml-8 no-underline dim"
+                     target="{{ $link['target'] }}">
+                {{ $link['name'] }}
             </a>
         </li>
     @endforeach

--- a/src/Links.php
+++ b/src/Links.php
@@ -8,13 +8,21 @@ use Laravel\Nova\Tool as BaseTool;
 class Links extends BaseTool
 {
     /**
+     * @var array $links
+     */
+    protected $links = [];
+
+    /**
      * Perform any tasks that need to happen when the tool is booted.
      *
      * @return void
      */
     public function boot()
     {
-        //
+        // Add Links from config file (for backward compatibility with v0.0.1)
+        foreach (config('nova-links.links') as $name => $href) {
+            $this->add($name, $href);
+        }
     }
 
     /**
@@ -24,6 +32,17 @@ class Links extends BaseTool
      */
     public function renderNavigation()
     {
-        return view('nova-links::navigation');
+        return view('nova-links::navigation', ['links' => $this->links]);
+    }
+
+    public function add($name, $href, $target = '_self')
+    {
+        $this->links[] = [
+            'name' => $name,
+            'href' => $href,
+            'target' => $target,
+        ];
+
+        return $this;
     }
 }

--- a/src/Links.php
+++ b/src/Links.php
@@ -35,6 +35,14 @@ class Links extends BaseTool
         return view('nova-links::navigation', ['links' => $this->links]);
     }
 
+    /**
+     * Add links to be displayed on Nova sidebar
+     *
+     * @param string $name Display name of the Link eg: "Tailwind Docs"
+     * @param string $href Link location eg: "https://tailwindcss.com/"
+     * @param string $target Default option '_self' opens link in same window. Set to '_blank' to open link in new tab.
+     * @return $this
+     */
     public function add($name, $href, $target = '_self')
     {
         $this->links[] = [


### PR DESCRIPTION
* Implements builder approach for configuring the tools as referenced in #1 and #3 
* Adds _blank option for opening links in new tab as referenced in #2 

The tool can be configured using below syntax

```php
public function tools()
{
    return [
        // ...
        (new \vmitchell85\NovaLinks\Links())
               ->add('Tailwind docs', 'https://tailwindcss.com/', '_blank'),
               ->add('Laravel docs', 'https://laravel.com/docs/5.5/'),
    ];
}

```

The first link `Tailwind docs` will open in new tab

The second `Laravel docs` will use default option to open in same window