### PR TITLE
Move left margin class to `li` instead of `a` element

### DIFF
--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -6,8 +6,8 @@
 </h3>
 <ul class="list-reset mb-8">
     @foreach ($links as $link)
-        <li class="leading-wide mb-4 text-sm">
-            <a href="{{ $link['href'] }}" class="text-white ml-8 no-underline dim"
+        <li class="leading-wide mb-4 ml-8 text-sm">
+            <a href="{{ $link['href'] }}" class="text-white no-underline dim"
                      target="{{ $link['target'] }}">
                 {{ $link['name'] }}
             </a>


### PR DESCRIPTION
This prevents awkward wrapping when the link labels are extra long and it matches the main Nova sidebar pattern.