### PR TITLE
Allow the navigation label in the Nova sidebar to be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,29 @@ return [
 ];
 
 ```
+
+### Change the Navigation Label
+
+The default heading that will appear in the Nova sidebar is 'Links'.
+
+You can change the navigation label by passing a string to the constructor:
+
+```php
+// in app/Providers/NovaServiceProvider.php
+
+// ...
+
+public function tools()
+{
+    return [
+        // ...
+        (new \vmitchell85\NovaLinks\Links('Documentation'))
+            ->add('Nova Docs', 'https://nova.laravel.com/docs')
+            ->add('Laravel Docs', 'https://laravel.com/docs', '_blank'),
+            
+        (new \vmitchell85\NovaLinks\Links('News'))
+            ->add('Laravel Blog', 'https://blog.laravel.com')
+            ->add('Laravel News', 'https://laravel-news.com'),
+    ];
+}
+```

--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -2,7 +2,7 @@
     <svg class="sidebar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
         <path fill="var(--sidebar-icon)"d="M9.26 13a2 2 0 0 1 .01-2.01A3 3 0 0 0 9 5H5a3 3 0 0 0 0 6h.08a6.06 6.06 0 0 0 0 2H5A5 5 0 0 1 5 3h4a5 5 0 0 1 .26 10zm1.48-6a2 2 0 0 1-.01 2.01A3 3 0 0 0 11 15h4a3 3 0 0 0 0-6h-.08a6.06 6.06 0 0 0 0-2H15a5 5 0 0 1 0 10h-4a5 5 0 0 1-.26-10z"/>
     </svg>
-    <span class="sidebar-label">{{ __('Links') }}</span>
+    <span class="sidebar-label">{{ __($label) }}</span>
 </h3>
 <ul class="list-reset mb-8">
     @foreach ($links as $link)

--- a/src/Links.php
+++ b/src/Links.php
@@ -8,9 +8,24 @@ use Laravel\Nova\Tool as BaseTool;
 class Links extends BaseTool
 {
     /**
+     * @var string $label
+     */
+    protected $label = 'Links';
+
+    /**
      * @var array $links
      */
     protected $links = [];
+
+    /**
+     * Create a new Tool.
+     *
+     * @return void
+     */
+    public function __construct(string $label = 'Links')
+    {
+        $this->label = $label;
+    }
 
     /**
      * Perform any tasks that need to happen when the tool is booted.
@@ -32,7 +47,10 @@ class Links extends BaseTool
      */
     public function renderNavigation()
     {
-        return view('nova-links::navigation', ['links' => $this->links]);
+        return view('nova-links::navigation', [
+            'label' => $this->label,
+            'links' => $this->links
+        ]);
     }
 
     /**


### PR DESCRIPTION
My application has quite a few links, and I like to group them under multiple headings to separate them.

I noticed this package only lets you use one label ("Links", by default). Whilst you could change the default label using translation files, it could only be changed once across all instances.

This backwards-compatible PR allows for customising the label that appears in the Nova sidebar. I updated the docs to show an example of how it might be used (and how two link blocks can be added, to group similar links in the UI).

Thanks for a useful package!