### PR TITLE
Add ability to open links in a new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ public function tools()
 }
 ```
 
+To open a link in a new browser window, set the third parameter on `addLink` or `addExternalLink` to `true`:
+
+```php
+// app/Providers/NovaServiceProvider.php
+
+// ...
+
+public function tools()
+{
+    return [
+        // ...
+        (new \vmitchell85\NovaLinks\Links('Laravel-related News'))
+            ->addLink('Nova Main', '/', true)
+            ->addExternalLink('Laravel News', 'https://laravel-news.com', true),
+    ];
+}
+```
+
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.

--- a/src/Links.php
+++ b/src/Links.php
@@ -45,12 +45,13 @@ class Links extends BaseTool
      *
      * @param string $name
      * @param string $href
+     * @param boolean $openInNewTab
      *
      * @return self
      */
-    public function addLink(string $name, string $href): self
+    public function addLink(string $name, string $href, bool $openInNewTab = false): self
     {
-        return $this->add($name, $href);
+        return $this->add($name, $href, $openInNewTab);
     }
 
     /**
@@ -58,12 +59,13 @@ class Links extends BaseTool
      *
      * @param string $name
      * @param string $href
+     * @param boolean $openInNewTab
      *
      * @return self
      */
-    public function addExternalLink(string $name, string $href): self
+    public function addExternalLink(string $name, string $href, bool $openInNewTab = false): self
     {
-        return $this->add($name, $href, true);
+        return $this->add($name, $href, $openInNewTab, true);
     }
 
     /**
@@ -71,16 +73,21 @@ class Links extends BaseTool
      *
      * @param string $name
      * @param string $href
+     * @param boolean $openInNewTab
      * @param boolean $external
      *
      * @return $this
      */
-    private function add(string $name, string $href, bool $external = false): self
+    private function add(string $name, string $href, bool $openInNewTab, bool $external = false): self
     {
         $link = MenuItem::link($name, $href);
 
         if ($external) {
             $link->external();
+        }
+
+        if ($openInNewTab) {
+            $link->openInNewTab();
         }
 
         $this->links[] = $link;


### PR DESCRIPTION
This PR adds the option to open links in a new browser window.

I'm not really sure about the implementation, not really like the third parameter. Nicer would be something like `->addLink(Link::make('Nova Main')->external()->addExternalLink())`, and let the `Link` class extend the Nova `MenuItem`. That would a large breaking change though. This is backward compatible, hence I've decided to go this route. What do you think?